### PR TITLE
Update styles.css

### DIFF
--- a/Origami-website-1-template-main/styles.css
+++ b/Origami-website-1-template-main/styles.css
@@ -28,7 +28,8 @@ body{
     border-radius: 50px;
 }
 .origami {
-    
+
+    text-align: center;
     border-radius: 20px;
     background-color: #808080;
     /* modify margin and padding here*/


### PR DESCRIPTION
Added the following :

.origami {
    text-align: center;
}

 Instead of using the <center> tag, which is deprecated in HTML5, you can use CSS to center your content.